### PR TITLE
Fix bugs and align with HA standards

### DIFF
--- a/custom_components/postnl/__init__.py
+++ b/custom_components/postnl/__init__.py
@@ -21,7 +21,7 @@ from .login_api import PostNLLoginAPI
 _LOGGER = logging.getLogger(__name__)
 
 
-async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
+async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up PostNL from config entry."""
     _LOGGER.debug("Setup Entry PostNL")
 
@@ -39,8 +39,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
     hass.data[DOMAIN][entry.entry_id] = {
         'auth': auth
     }
-
-    _LOGGER.debug('Using access token: %s', auth.access_token)
 
     postnl_login_api = PostNLLoginAPI(auth.access_token)
 
@@ -88,7 +86,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Unload PostNL config entry."""
-    _LOGGER.debug('Reloading PostNL integration')
+    _LOGGER.debug('Unloading PostNL integration')
     unload_ok = await hass.config_entries.async_unload_platforms(entry, PLATFORMS)
 
     if unload_ok:
@@ -126,7 +124,7 @@ class AsyncConfigEntryAuth:
 
         except (ClientResponseError, ClientError) as exception:
             _LOGGER.debug("API error: %s", exception)
-            if exception.status == 400:
+            if isinstance(exception, ClientResponseError) and exception.status == 400:
                 self.oauth_session.config_entry.async_start_reauth(
                     self.oauth_session.hass
                 )

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -27,8 +27,8 @@ class PostNLCoordinator(DataUpdateCoordinator):
             _LOGGER,
             name="PostNL",
             update_interval=timedelta(seconds=90),
+            config_entry=entry,
         )
-        self.config_entry = entry
         _LOGGER.debug("PostNLCoordinator initialized with update interval: %s", self.update_interval)
         
     async def _async_update_data(self) -> dict[str, list[Package]]:

--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -3,6 +3,7 @@ import logging
 from datetime import timedelta
 
 import requests
+from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.update_coordinator import (DataUpdateCoordinator,
                                                       UpdateFailed)
@@ -19,7 +20,7 @@ class PostNLCoordinator(DataUpdateCoordinator):
     graphq_api: PostNLGraphql
     jouw_api: PostNLJouwAPI
 
-    def __init__(self, hass: HomeAssistant) -> None:
+    def __init__(self, hass: HomeAssistant, entry: ConfigEntry) -> None:
         """Initialize PostNL coordinator."""
         super().__init__(
             hass,
@@ -27,6 +28,7 @@ class PostNLCoordinator(DataUpdateCoordinator):
             name="PostNL",
             update_interval=timedelta(seconds=90),
         )
+        self.config_entry = entry
         _LOGGER.debug("PostNLCoordinator initialized with update interval: %s", self.update_interval)
         
     async def _async_update_data(self) -> dict[str, list[Package]]:

--- a/custom_components/postnl/manifest.json
+++ b/custom_components/postnl/manifest.json
@@ -8,6 +8,6 @@
   "integration_type": "hub",
   "iot_class": "cloud_polling",
   "issue_tracker": "https://github.com/arjenbos/ha-postnl/issues",
-  "requirements": ["gql"],
-  "version": "2.1.1"
+  "requirements": ["gql", "requests"],
+  "version": "2.2.0"
 }

--- a/custom_components/postnl/sensor.py
+++ b/custom_components/postnl/sensor.py
@@ -1,10 +1,10 @@
 """Sensor for PostNL packages."""
 import logging
 
+from homeassistant.components.sensor import SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant, callback
-from homeassistant.helpers.device_registry import DeviceInfo
-from homeassistant.helpers.entity import Entity
+from homeassistant.helpers.device_registry import DeviceEntryType, DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from homeassistant.helpers.entity_registry import async_get as async_get_entity_registry
 
@@ -19,7 +19,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     """Set up the PostNL sensor platform."""
     _LOGGER.debug("Setting up PostNL sensors")
 
-    coordinator = PostNLCoordinator(hass)
+    coordinator = PostNLCoordinator(hass, entry)
     await coordinator.async_config_entry_first_refresh()
     
     userinfo = hass.data[DOMAIN][entry.entry_id].get("userinfo", {})
@@ -46,7 +46,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     ])
     _LOGGER.debug("PostNL sensors added")
 
-class PostNLDelivery(CoordinatorEntity, Entity):
+class PostNLDelivery(CoordinatorEntity, SensorEntity):
+    _attr_icon = "mdi:package-variant-closed"
+    _attr_native_unit_of_measurement = "packages"
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
     def __init__(self, coordinator, postnl_userinfo, unique_id, name, receiver: bool = True):
         """Initialize the PostNL sensor."""
         super().__init__(coordinator, context=name)
@@ -75,6 +79,8 @@ class PostNLDelivery(CoordinatorEntity, Entity):
             },
             name=self.postnl_userinfo.get('email'),
             manufacturer="PostNL",
+            entry_type=DeviceEntryType.SERVICE,
+            configuration_url="https://jouw.postnl.nl",
         )
 
     @property
@@ -83,24 +89,14 @@ class PostNLDelivery(CoordinatorEntity, Entity):
         return self._name
 
     @property
-    def state(self):
+    def native_value(self):
         """Return the state of the sensor."""
         return self._state
-
-    @property
-    def unit_of_measurement(self):
-        """Return the unit of measurement of this entity, if any."""
-        return 'packages'
 
     @property
     def extra_state_attributes(self):
         """Return the state attributes."""
         return self._attributes
-
-    @property
-    def icon(self):
-        """Icon to use in the frontend."""
-        return "mdi:package-variant-closed"
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -114,10 +110,13 @@ class PostNLDelivery(CoordinatorEntity, Entity):
         self._attributes['delivered'] = []
         self._attributes['enroute'] = []
 
+        if not self.coordinator.data:
+            return
+
         if self.receiver:
-            coordinator_data = self.coordinator.data['receiver']
+            coordinator_data = self.coordinator.data.get('receiver', [])
         else:
-            coordinator_data = self.coordinator.data['sender']
+            coordinator_data = self.coordinator.data.get('sender', [])
 
         for package in coordinator_data:
             if package.delivered:


### PR DESCRIPTION
While working on a [DHL component ](https://github.com/peternijssen/ha-dhl-nl) with Claude, I've requested Claude to also review this repository. I believe it found valid improvements and fixes. Just waiting for a package to arrive in PostNL to see if everything still functions as expected.

### Bug fixes
* AttributeError on coordinator update — PostNLCoordinator referenced self.config_entry without ever assigning it. The constructor now accepts and stores the ConfigEntry.
* Wrong base class — PostNLDelivery inherited from Entity instead of SensorEntity, preventing correct registration as a sensor platform entity.
* Crash on None coordinator data — handle_coordinator_data accessed coordinator.data['receiver'] directly without guarding against None, which is always the case when called from __init__ before the first refresh. Now uses .get() with a fallback and an early return.
*AttributeError on ClientError.status — only ClientResponseError has a status attribute, not the parent ClientError. Added an isinstance check before accessing .status.
### Security
* OAuth access token removed from logs — auth.access_token was logged at debug level, exposing a live token to anyone with HA log access.
### HA standards
* SensorStateClass.MEASUREMENT added to both sensors, enabling long-term statistics in HA.
* DeviceEntryType.SERVICE and configuration_url added to DeviceInfo.
* state and unit_of_measurement properties replaced with native_value and _attr_native_unit_of_measurement / _attr_icon class variables (modern HA pattern since 2022.5).
* requests added to manifest.json requirements.
### Minor
* async_setup_entry return type corrected from -> True to -> bool.
* Log message in async_unload_entry corrected from "Reloading" to "Unloading".