### PR TITLE
Add expected delivery window

### DIFF
--- a/custom_components/postnl/coordinator.py
+++ b/custom_components/postnl/coordinator.py
@@ -90,25 +90,30 @@ class PostNLCoordinator(DataUpdateCoordinator):
             colli = track_and_trace_details.get('colli', {}).get(shipment['barcode'], {})
 
             status_message = "Unknown"
+            expected_datetime = None
+            expected_from = None
+            expected_to = None
+            last_update = None
 
             if colli:
                 _LOGGER.debug("Colli details found for shipment %s: %s", shipment['key'], colli)
-                if colli.get("routeInformation"):
-                    route_information = colli.get("routeInformation")
-                    planned_date = route_information.get("plannedDeliveryTime")
-                    planned_from = route_information.get("plannedDeliveryTimeWindow", {}).get("startDateTime")
-                    planned_to = route_information.get("plannedDeliveryTimeWindow", {}).get('endDateTime')
+                if colli.get('routeInformation'):
+                    route_information = colli.get('routeInformation')
+                    planned_date = route_information.get('plannedDeliveryTime')
+                    planned_from = route_information.get('plannedDeliveryTimeWindow', {}).get('startDateTime')
+                    planned_to = route_information.get('plannedDeliveryTimeWindow', {}).get('endDateTime')
                     expected_datetime = route_information.get('expectedDeliveryTime')
+                    expected_from = route_information.get('expectedDeliveryTimeWindow', {}).get('startDateTime')
+                    expected_to = route_information.get('expectedDeliveryTimeWindow', {}).get('endDateTime')
+                    last_update = route_information.get('lastUpdate')
                 elif colli.get('eta'):
                     planned_date = colli.get('eta', {}).get('start')
                     planned_from = colli.get('eta', {}).get('start')
                     planned_to = colli.get('eta', {}).get('end')
-                    expected_datetime = None
                 else:
                     planned_date = shipment.get('deliveryWindowFrom', None)
                     planned_from = shipment.get('deliveryWindowFrom', None)
                     planned_to = shipment.get('deliveryWindowTo', None)
-                    expected_datetime = None
 
                 status_message = colli.get('statusPhase', {}).get('message', "Unknown")
             else:
@@ -116,7 +121,6 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 planned_date = shipment.get('deliveryWindowFrom', None)
                 planned_from = shipment.get('deliveryWindowFrom', None)
                 planned_to = shipment.get('deliveryWindowTo', None)
-                expected_datetime = None
 
             return Package(
                 key=shipment.get('key'),
@@ -130,7 +134,10 @@ class PostNLCoordinator(DataUpdateCoordinator):
                 planned_date=planned_date,
                 planned_from=planned_from,
                 planned_to=planned_to,
-                expected_datetime=expected_datetime
+                expected_datetime=expected_datetime,
+                expected_from=expected_from,
+                expected_to=expected_to,
+                last_update=last_update
             )
         except requests.exceptions.RequestException as exception:
             _LOGGER.error("Error fetching Track and Trace details for shipment %s: %s", shipment.get('key'), exception, exc_info=True)

--- a/custom_components/postnl/structs/package.py
+++ b/custom_components/postnl/structs/package.py
@@ -11,6 +11,9 @@ class Package:
     planned_from: str | None
     planned_to: str | None
     expected_datetime: str | None
+    expected_from: str | None
+    expected_to: str | None
+    last_update: str | None
 
     def __init__(
             self,
@@ -26,6 +29,9 @@ class Package:
             planned_from: str | None = None,
             planned_to: str | None = None,
             expected_datetime: str | None = None,
+            expected_from: str | None = None,
+            expected_to: str | None = None,
+            last_update: str | None = None,
     ):
         self.key = key
         self.name = name
@@ -39,3 +45,6 @@ class Package:
         self.planned_from = planned_from
         self.planned_to = planned_to
         self.expected_datetime = expected_datetime
+        self.expected_from = expected_from
+        self.expected_to = expected_to
+        self.last_update = last_update


### PR DESCRIPTION
The PostNL app shows a more accurate delivery window when the delivery is on its way in the `expectedDeliveryTimeWindow`, which is currently missing from this integration.

This PR adds fields to indicate this expected delivery window as well as a timestamp of the last update of the driver as separate fields as to not create a breaking change for users relying on the `planned_to` and `planned_from` range.