### PR TITLE
Fix reauth UX: friendly entry title and dialog description

### DIFF
--- a/custom_components/postnl/__init__.py
+++ b/custom_components/postnl/__init__.py
@@ -25,6 +25,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> True:
     """Set up PostNL from config entry."""
     _LOGGER.debug("Setup Entry PostNL")
 
+    if entry.title != "PostNL":
+        hass.config_entries.async_update_entry(entry, title="PostNL")
+
     hass.data.setdefault(DOMAIN, {})
 
     implementation = await async_get_config_entry_implementation(hass, entry)

--- a/custom_components/postnl/__init__.py
+++ b/custom_components/postnl/__init__.py
@@ -8,7 +8,7 @@ from gql.transport.exceptions import TransportQueryError
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import CONF_ACCESS_TOKEN
 from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import (ConfigEntryNotReady, HomeAssistantError)
+from homeassistant.exceptions import (ConfigEntryAuthFailed, ConfigEntryNotReady, HomeAssistantError)
 from homeassistant.helpers import config_entry_oauth2_flow
 from homeassistant.helpers import device_registry as dr, entity_registry as er
 from homeassistant.helpers.config_entry_oauth2_flow import (
@@ -127,9 +127,7 @@ class AsyncConfigEntryAuth:
         except (ClientResponseError, ClientError) as exception:
             _LOGGER.debug("API error: %s", exception)
             if exception.status == 400:
-                self.oauth_session.config_entry.async_start_reauth(
-                    self.oauth_session.hass
-                )
+                raise ConfigEntryAuthFailed(exception) from exception
 
             raise HomeAssistantError(exception) from exception
         except TransportQueryError as exception:

--- a/custom_components/postnl/config_flow.py
+++ b/custom_components/postnl/config_flow.py
@@ -39,8 +39,10 @@ class OAuth2FlowHandler(
     async def async_oauth_create_entry(self, data: dict) -> dict:
         """Create an oauth config entry or update existing entry for reauth."""
         if self.reauth_entry:
-            self.hass.config_entries.async_update_entry(self.reauth_entry, data=data)
+            self.hass.config_entries.async_update_entry(
+                self.reauth_entry, title="PostNL", data=data
+            )
             await self.hass.config_entries.async_reload(self.reauth_entry.entry_id)
             return self.async_abort(reason="reauth_successful")
 
-        return await super().async_oauth_create_entry(data)
+        return self.async_create_entry(title="PostNL", data=data)

--- a/custom_components/postnl/strings.json
+++ b/custom_components/postnl/strings.json
@@ -1,5 +1,16 @@
 {
     "application_credentials": {
         "description": "IMPORTANT: installing this integration is only possible if you use the Chrome extension (see Github repo). You can just put in random data in the Client ID and Client secret fields, the integration ignores the information."
+    },
+    "config_flow": {
+        "step": {
+            "reauth_confirm": {
+                "title": "Opnieuw inloggen bij PostNL",
+                "description": "Je PostNL-sessie is verlopen. Klik op Verzenden om opnieuw in te loggen."
+            }
+        },
+        "abort": {
+            "reauth_successful": "Opnieuw inloggen geslaagd"
+        }
     }
 }

--- a/custom_components/postnl/translations/en.json
+++ b/custom_components/postnl/translations/en.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "step": {
+            "reauth_confirm": {
+                "title": "Re-authenticate with PostNL",
+                "description": "Your PostNL session has expired. Click Submit to log in again."
+            }
+        },
+        "abort": {
+            "reauth_successful": "Re-authentication was successful"
+        }
+    }
+}

--- a/custom_components/postnl/translations/nl.json
+++ b/custom_components/postnl/translations/nl.json
@@ -1,0 +1,13 @@
+{
+    "config": {
+        "step": {
+            "reauth_confirm": {
+                "title": "Opnieuw inloggen bij PostNL",
+                "description": "Je PostNL-sessie is verlopen. Klik op Verzenden om opnieuw in te loggen."
+            }
+        },
+        "abort": {
+            "reauth_successful": "Opnieuw inloggen geslaagd"
+        }
+    }
+}


### PR DESCRIPTION
- Set config entry title to "PostNL" instead of the raw client_id, both on first install and when re-authenticating
- Add config_flow strings for reauth_confirm step so the dialog shows a title and explanation instead of an empty form